### PR TITLE
Added support for `ScanStmt`.

### DIFF
--- a/src/ir2dsl.js
+++ b/src/ir2dsl.js
@@ -101,7 +101,6 @@ const statement_processors = {
   ResetLocalStmt: ['target'],
   ResultSetAddStmt: ['value'],
   ReturnLocalStmt: ['source'],
-  // TODO(dkorolev): `ScanStmt`.
   SetAddStmt: ['value', 'set'],
   // TODO(dkorolev): `WithStmt`.
 
@@ -152,6 +151,15 @@ const statement_processors = {
       emit(`  CallStmtPassArg(${arg_index}, ${wrap(arg)})`);
     });
     emit(`CallStmtEnd(Func(${funcs[e.stmt.func]}), Local(${e.stmt.result}))`);
+  },
+
+  ScanStmt: e => {
+    emit(`ScanStmtBegin(Local(${e.stmt.source}), ${e.stmt.key}, ${e.stmt.value}, RowCol(${e.stmt.row}, ${e.stmt.col}))`);
+    const save_indent = global_indent;
+    global_indent = global_indent + '  ';
+    processStatements(e.stmt.block.stmts);
+    global_indent = save_indent;
+    emit('ScanStmtEnd()');
   },
 };
 

--- a/src/preprocess.inl.js
+++ b/src/preprocess.inl.js
@@ -44,6 +44,23 @@ const opa_object_get_by_key = (x, key) => {
   }
 };
 
+const opa_scan = (source, locals, key_index, value_index, block) => {
+  console.log(JSON.stringify(source));
+  if (source.t === 'array') {
+    source.v.forEach((e, i) => {
+      locals[key_index] = {t:'number', v:i};
+      locals[value_index] = JSON.parse(JSON.stringify(e));
+      block();
+    });
+  } else if (source.t === 'object') {
+    for (let k in source.v) {
+      locals[key_index] = {t:'string', v:k};
+      locals[value_index] = JSON.parse(JSON.stringify(source.v[k]));
+      block();
+    }
+  }
+};
+
 const internal_to_external_impl = {
   number: (x) => { return x; },
   string: (x) => { return x; },
@@ -162,7 +179,6 @@ const wrap_for_assignment = (x) => {
 #define AssignVarStmt(source, target, rowcol) target = wrap_for_assignment(source);
 // TODO(dkorolev): `BreakStmt`.
 // TODO(dkorolev): `CallDynamicStmt`.
-// TODO(dkorolev): `CallStmt`.
 #define CallStmtBegin(func, target, rowcol) target = (() => { let args = [];
 #define CallStmtPassArg(arg_index, arg_value) args[arg_index] = arg_value;
 #define CallStmtEnd(func, target) return opa_get_function_impl(func)(args)})();
@@ -188,7 +204,8 @@ const wrap_for_assignment = (x) => {
 #define ResetLocalStmt(target, rowcol) target = undefined;
 #define ResultSetAddStmt(value, rowcol) result.push(value);  // TODO(dkorolev): Checks?
 #define ReturnLocalStmt(source, rowcol) retval = source; // TODO(dkorolev): Is this even important given we know the return "local" index?
-// TODO(dkorolev): `ScanStmt`.
+#define ScanStmtBegin(source, key, value, rowcol) opa_scan(source, locals, key, value, () => {
+#define ScanStmtEnd() });
 #define SetAddStmt(value, set, rowcol) set.v[value] = true;
 // TODO(dkorolev): `WithStmt`.
 

--- a/src/preprocess.inl.js
+++ b/src/preprocess.inl.js
@@ -45,7 +45,6 @@ const opa_object_get_by_key = (x, key) => {
 };
 
 const opa_scan = (source, locals, key_index, value_index, block) => {
-  console.log(JSON.stringify(source));
   if (source.t === 'array') {
     source.v.forEach((e, i) => {
       locals[key_index] = {t:'number', v:i};

--- a/tests/rbac_example/self_contained/rbac_example.rego
+++ b/tests/rbac_example/self_contained/rbac_example.rego
@@ -1,0 +1,26 @@
+#!TEST rbac allow
+
+# An example case from https://www.styra.com/blog/4-best-practices-for-microservices-authorization/
+
+package rbac
+
+user_roles := {
+  "alice": ["eng", "web"],
+  "bob": ["hr"]  # NOTE: "hr"` without `[]` would be a good example of strong typing.
+}
+
+role_permissions := {
+ "eng": [{"action": "read", "object": "server123"}],
+ "web": [{"action": "read", "object": "server123"},
+         {"action": "write", "object": "server123"}],
+ "hr": [{"action": "read", "object": "database456"}],
+}
+
+default allow = false
+allow {
+  roles := user_roles[input.user]
+  r := roles[_]
+  permissions := role_permissions[r]
+  p := permissions[_]
+  p == {"action": input.action, "object": input.object}
+}

--- a/tests/rbac_example/self_contained/tests.json
+++ b/tests/rbac_example/self_contained/tests.json
@@ -1,0 +1,8 @@
+{"user":"alice","action":"read","object":"server123"}
+{"user":"alice","action":"read","object":"database456"}
+{"user":"alice","action":"write","object":"server123"}
+{"user":"alice","action":"write","object":"database456"}
+{"user":"bob","action":"read","object":"server123"}
+{"user":"bob","action":"read","object":"database456"}
+{"user":"bob","action":"write","object":"server123"}
+{"user":"bob","action":"write","object":"database456"}


### PR DESCRIPTION
The policy from [this blog post](https://www.styra.com/blog/4-best-practices-for-microservices-authorization/) is now passing the tests while evaluated from a transpiled JavaScript:

![image](https://user-images.githubusercontent.com/2159447/178127191-73003ed3-546b-42bb-88cb-d3c7e1368a06.png)

Builtin functions aside, this means that, together with https://github.com/C5T/asbyrgi/pull/11 that is now merged, the OPA IR functionality is 95+% covered by our DSL, enough to run simple demos. Fingers crossed it will be 100% some day soon!

I've put the example policy under `rbac_exampl/self_contained`, so that later on some `rbac_example/using_data` can be added. The latter would demonstrate the use case where the "allowlist" is dynamic, not hardcoded in the `.rego` file. Hope to get to this some time soon.