### PR TITLE
Preparing the DSL to be Kotlin-autogen-friendly, baby steps.

### DIFF
--- a/scripts/gen_all_js_tests.sh
+++ b/scripts/gen_all_js_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-(cd tests; find . -iname '*.rego' | xargs node all_tests.js.regenerate.js >all_tests.js)
+(cd tests; find . -iname '*.rego' | sort | xargs node all_tests.js.regenerate.js >all_tests.js)
 
 cat >tests/mocha.html <<EOF
 <!doctype html>

--- a/src/preprocess.inl.js
+++ b/src/preprocess.inl.js
@@ -301,9 +301,11 @@ const wrap_for_assignment = (x) => {
 #define AssignVarStmt(source, target, rowcol) target = wrap_for_assignment(source);
 // TODO(dkorolev): `BreakStmt`.
 // TODO(dkorolev): `CallDynamicStmt`.
-#define CallStmtBegin(func, target, rowcol) target = (() => { let args = [];
 #define CallStmtPassArg(arg_index, arg_value) args[arg_index] = arg_value;
-#define CallStmtEnd(func, target) return opa_get_function_impl(func)(args)})();
+#define CallBuiltinStmtBegin(func, target, rowcol) target = (() => { let args = [];
+#define CallBuiltinStmtEnd(func, target) return opa_get_function_impl( {builtin_func: opa_builtins.func} )(args)})();
+#define CallUserStmtBegin(func, target, rowcol) target = (() => { let args = [];
+#define CallUserStmtEnd(func, target) return opa_get_function_impl(func)(args)})();
 #define NotStmtBegin(rowcol) if ((() => {
 #define NotStmtEnd() ; return true; })() === true) return;
 #define DotStmt(source, key, target, rowcol) target = opa_object_get_by_key(source, key);
@@ -340,9 +342,6 @@ const wrap_for_assignment = (x) => {
 
 #define BareNumber(a) a
 #define StringConstantIndex(a) a
-
-#define Func(x) x
-#define BuiltinFunc(x) {builtin_func: opa_builtins.x}
 
 // TODO(dkorolev): The `result` should not be global.
 #define BeginPlan(plan_index, plan_name) plans[plan_name] = (input, data) => { let locals = [input, data]; let result = [];


### PR DESCRIPTION
Hey @mzhurovich!

Really no need to review this one, merging it in right away.

I'm just back-testing that the (minor so far) DSL change for Kotlin is compatible with JS -- and so far all is good, with local & Github-hosted tests passing.

Technicalities:

* Retired `Func()` and `BuiltinFunc()`.
* Replaced `CallStmt{Begin,End}()` by `Call{Builtin,User}Stmt{Begin,End}()`.

Might need more, but this passed (yay!) the first Kotlin end-to-end test -- with the code I'm preparing in the next branch/PR.

Thx,
Dima